### PR TITLE
Add shortcuts for leetcode and Google Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Traditional searching is a two-step process for GMail, Drive, GitHub and many mo
 | spotify | <https://open.spotify.com/browse/featured> | goto spotify Gotye |
 | stack | <https://stackoverflow.com/> | goto stack HTML5 |
 | stackoverflow | <https://stackoverflow.com/> | goto stackoverflow |
+|leet | <https://leetcode.com/> | goto leetcode |
+|cal | <https://calendar.google.com/> | goto calendar |
+|calendar | <https://calendar.google.com/> | goto calendar |
 | tax | <https://www.incometaxindiaefiling.gov.in/> | goto tax |
 | trello | <https://trello.com/> | goto trello Anirudh |
 | twit | <https://x.com/> | goto twit Grynn |

--- a/src/config.json
+++ b/src/config.json
@@ -295,6 +295,21 @@
 		"search": "https://stackoverflow.com/search?q={0}",
 		"param": ""
 	},
+	"cal": {
+		"default": "https://calendar.google.com/",
+		"search": "https://calendar.google.com/calendar/u/0/r/search?q={0}",
+		"param": "meeting"
+	},
+	"calendar": {
+		"default": "https://calendar.google.com/",
+		"search": "https://calendar.google.com/calendar/u/0/r/search?q={0}",
+		"param": "meeting"
+	},
+	"leet": {
+		"default": "https://leetcode.com/",
+		"search": "https://leetcode.com/problemset/all/?search={0}",
+		"param": "two sum"
+	},
 	"bitly": {
 		"default": "https://bitly.com/",
 		"param": ""


### PR DESCRIPTION
This PR adds support for shortcuts for both Leetcode and Google calendar.  It modifies `config.json` and `README.md`. Closes #22 .